### PR TITLE
Feat/improve signature err msg

### DIFF
--- a/src/helpers/JWTGeneric/JWTGeneric.test.ts
+++ b/src/helpers/JWTGeneric/JWTGeneric.test.ts
@@ -1,6 +1,6 @@
 import { JWTGeneric } from './JWTGeneric';
 import { addDate } from '../timestampHelper/timestampHelper';
-import { JSONRPCErrors } from '../../models/JSONRPCError';
+import { JWTGenericErrors } from '../../models/JWTGenericErrors';
 
 const Web3 = require('web3');
 
@@ -45,7 +45,7 @@ describe('JWTGeneric', function () {
         .verify('0x74FE09Db23Df5c35d2969B666f7AA94621E110');
 
       expect(isValid).toBeFalsy();
-      expect(details).toBe(JSONRPCErrors.wrongSignatureForPayload);
+      expect(details).toBe(JWTGenericErrors.publicKeyAndDecodedKeyMismatch);
     });
 
     test('it should verify the right pubkey and say true', () => {
@@ -81,7 +81,7 @@ describe('JWTGeneric', function () {
           .verify(pubKey);
 
         expect(isValid).toBeFalsy();
-        expect(details).toBe(JSONRPCErrors.authorizationsJWTExpired);
+        expect(details).toBe(JWTGenericErrors.authorizationsJWTExpired);
       });
       test('it should be true if not expired', async () => {
         const jwt = new JWTGeneric(signer, decoder as any);
@@ -123,7 +123,7 @@ describe('JWTGeneric', function () {
           .verify(pubKey);
 
         expect(isValid).toBeFalsy();
-        expect(details).toBe(JSONRPCErrors.authorizationsJWTNotBefore);
+        expect(details).toBe(JWTGenericErrors.authorizationsJWTNotBefore);
       });
 
       test('it should be true if after nbf', async () => {
@@ -166,7 +166,7 @@ describe('JWTGeneric', function () {
           .verify(pubKey);
 
         expect(isValid).toBeFalsy();
-        expect(details).toBe(JSONRPCErrors.authorizationsJWTBeforeIat);
+        expect(details).toBe(JWTGenericErrors.authorizationsJWTBeforeIat);
       });
 
       test('it should be true if after iat', async () => {
@@ -267,7 +267,7 @@ describe('JWTGeneric', function () {
           .verify(pubKey);
 
         expect(isValid).toBeFalsy();
-        expect(details).toBe(JSONRPCErrors.authorizationsJWTBeforeIat);
+        expect(details).toBe(JWTGenericErrors.authorizationsJWTBeforeIat);
       });
 
       test('expected token should be good', async () => {

--- a/src/helpers/JWTGeneric/JWTGeneric.ts
+++ b/src/helpers/JWTGeneric/JWTGeneric.ts
@@ -1,6 +1,6 @@
 import { Base64 } from 'js-base64';
 import { ErrorPayload } from '../../models/jsonrpc/errorPayload';
-import { JSONRPCErrors } from '../../models/JSONRPCError';
+import { JWTGenericErrors } from '../../models/JWTGenericErrors';
 
 export class JWTGeneric {
   private header = {
@@ -126,7 +126,7 @@ export class JWTGeneric {
 
     return {
       isValid: isPubKeyValid,
-      details: isPubKeyValid ? details : JSONRPCErrors.wrongSignatureForPayload
+      details: isPubKeyValid ? details : JWTGenericErrors.publicKeyAndDecodedKeyMismatch
     };
   }
 
@@ -136,7 +136,7 @@ export class JWTGeneric {
       if (isExpired) {
         return {
           isValid: false,
-          details: JSONRPCErrors.authorizationsJWTExpired
+          details: JWTGenericErrors.authorizationsJWTExpired
         };
       }
     }
@@ -145,7 +145,7 @@ export class JWTGeneric {
       if (isBefore) {
         return {
           isValid: false,
-          details: JSONRPCErrors.authorizationsJWTNotBefore
+          details: JWTGenericErrors.authorizationsJWTNotBefore
         };
       }
     }
@@ -154,7 +154,7 @@ export class JWTGeneric {
       if (isBefore) {
         return {
           isValid: false,
-          details: JSONRPCErrors.authorizationsJWTBeforeIat
+          details: JWTGenericErrors.authorizationsJWTBeforeIat
         };
       }
     }

--- a/src/models/JSONRPCError.ts
+++ b/src/models/JSONRPCError.ts
@@ -9,7 +9,7 @@ export const JSONRPCErrors = {
   wrongSignatureForPayload: {
     code: 1,
     details: {},
-    message: 'The signature of the payload or the signature of blockchain wallets do not correpond'
+    message: 'The signature of the payload or the signature of blockchain wallets do not correspond'
   },
   notHasReadRight: {
     code: 2,
@@ -25,5 +25,20 @@ export const JSONRPCErrors = {
     code: 4,
     details: {},
     message: 'Blockchain wallet does not pass strategy to join room'
+  },
+  authorizationsJWTExpired: {
+    code: 5,
+    details: {},
+    message: 'The authorizations JWT is expired'
+  },
+  authorizationsJWTNotBefore: {
+    code: 6,
+    details: {},
+    message: 'The authorizations JWT nbf is greater than the current date'
+  },
+  authorizationsJWTBeforeIat: {
+    code: 7,
+    details: {},
+    message: 'The authorizations JWT iat is greater than the current date'
   }
 };

--- a/src/models/JSONRPCError.ts
+++ b/src/models/JSONRPCError.ts
@@ -1,5 +1,3 @@
-import { ErrorPayload } from './jsonrpc/errorPayload';
-
 export const JSONRPCErrors = {
   unknownError: {
     code: -1,

--- a/src/models/JWTGenericErrors.ts
+++ b/src/models/JWTGenericErrors.ts
@@ -1,0 +1,27 @@
+export const JWTGenericErrors = {
+  unknownError: {
+    code: -1,
+    details: {},
+    message: 'This error is not handled please see details'
+  },
+  publicKeyAndDecodedKeyMismatch: {
+    code: 1,
+    details: {},
+    message: 'The public key does not correspond to the decoded key'
+  },
+  authorizationsJWTExpired: {
+    code: 2,
+    details: {},
+    message: 'The authorizations JWT is expired'
+  },
+  authorizationsJWTNotBefore: {
+    code: 3,
+    details: {},
+    message: 'The authorizations JWT nbf is greater than the current date'
+  },
+  authorizationsJWTBeforeIat: {
+    code: 4,
+    details: {},
+    message: 'The authorizations JWT iat is greater than the current date'
+  }
+};

--- a/src/models/authorizationsStatus.ts
+++ b/src/models/authorizationsStatus.ts
@@ -1,3 +1,5 @@
+import { ErrorPayload } from './jsonrpc/errorPayload';
+
 export interface AuthorizationsDetails {
     blockchainWalletAddress: string,
     proxyWallet: string,
@@ -5,5 +7,6 @@ export interface AuthorizationsDetails {
 }
 export interface AuthorizationsStatus {
     isAuthorized:boolean,
+    details?: ErrorPayload[],
     authorizations: AuthorizationsDetails[]
 }

--- a/src/services/JSONRPCServer/bouncer/bouncer.ts
+++ b/src/services/JSONRPCServer/bouncer/bouncer.ts
@@ -21,7 +21,7 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = details[0];
+          const errorPayload:ErrorPayload[] = details;
           return callback(errorPayload);
         }
 
@@ -50,7 +50,7 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = details[0];
+          const errorPayload:ErrorPayload[] = details;
           return callback(errorPayload);
         }
 
@@ -79,7 +79,7 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
       const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload:ErrorPayload = details[0];
+        const errorPayload:ErrorPayload[] = details;
         return callback(errorPayload);
       }
 
@@ -111,7 +111,7 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = details[0];
+          const errorPayload:ErrorPayload[] = details;
           return callback(errorPayload);
         }
 

--- a/src/services/JSONRPCServer/bouncer/bouncer.ts
+++ b/src/services/JSONRPCServer/bouncer/bouncer.ts
@@ -17,10 +17,11 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { authorizations, roomId, sectionId } = params;
         requiredDefined(authorizations, 'authorizations should be defined');
 
-        const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+        console.info(params);
+        const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+          const errorPayload:ErrorPayload = details[0];
           return callback(errorPayload);
         }
 
@@ -46,10 +47,10 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { authorizations } = params;
         requiredDefined(authorizations, 'authorizations should be defined');
 
-        const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+        const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+          const errorPayload:ErrorPayload = details[0];
           return callback(errorPayload);
         }
 
@@ -75,10 +76,10 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
       requiredDefined(roomId, 'roomId should be defined');
       requiredDefined(authorizations, 'authorizations should be defined');
 
-      const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+      const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload:ErrorPayload = details[0];
         return callback(errorPayload);
       }
 
@@ -107,10 +108,10 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { authorizations, roomId, sectionId, userProfile } = params;
         requiredDefined(authorizations, 'authorizations should be defined');
 
-        const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+        const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {
-          const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+          const errorPayload:ErrorPayload = details[0];
           return callback(errorPayload);
         }
 

--- a/src/services/JSONRPCServer/bouncer/bouncer.ts
+++ b/src/services/JSONRPCServer/bouncer/bouncer.ts
@@ -17,7 +17,6 @@ export const bouncerJSONRPCFactory = (networkParameters: NetworkParameters) =>
         const { authorizations, roomId, sectionId } = params;
         requiredDefined(authorizations, 'authorizations should be defined');
 
-        console.info(params);
         const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
         if (isAuthorized === false) {

--- a/src/services/JSONRPCServer/messages/messages.ts
+++ b/src/services/JSONRPCServer/messages/messages.ts
@@ -20,9 +20,6 @@ export const messagesJSONRPCFactory = (networkParameters:NetworkParameters) => (
       requiredDefined(authorizations, 'authorizations should be defined');
 
       const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
-      console.info('fetch messages infos');
-      console.info(isAuthorized, blockchainWallets, details);
-      console.info(authorizations, params);
 
       if (isAuthorized === false) {
         const errorPayload:ErrorPayload[] = details;

--- a/src/services/JSONRPCServer/messages/messages.ts
+++ b/src/services/JSONRPCServer/messages/messages.ts
@@ -66,11 +66,11 @@ export const messagesJSONRPCFactory = (networkParameters:NetworkParameters) => (
       requiredDefined(content, 'content should be defined');
       requiredDefined(authorizations, 'authorizations should be defined');
 
-      const { isAuthorized, blockchainWallets, proxyWalletAddress } = await utils.rightService
+      const { isAuthorized, blockchainWallets, proxyWalletAddress, details } = await utils.rightService
         .verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload:ErrorPayload[] = details;
         return callback(errorPayload);
       }
       const firstBlockchainWallet = blockchainWallets[0];

--- a/src/services/JSONRPCServer/messages/messages.ts
+++ b/src/services/JSONRPCServer/messages/messages.ts
@@ -19,10 +19,13 @@ export const messagesJSONRPCFactory = (networkParameters:NetworkParameters) => (
       requiredDefined(sectionId, 'sectionId should be defined');
       requiredDefined(authorizations, 'authorizations should be defined');
 
-      const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+      const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
+      console.info('fetch messages infos');
+      console.info(isAuthorized, blockchainWallets, details);
+      console.info(authorizations, params);
 
       if (isAuthorized === false) {
-        const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload:ErrorPayload[] = details;
         return callback(errorPayload);
       }
 
@@ -110,10 +113,10 @@ export const messagesJSONRPCFactory = (networkParameters:NetworkParameters) => (
       requiredDefined(roomId, 'roomId should be defined');
       requiredDefined(authorizations, 'authorizations should be defined');
 
-      const { isAuthorized, blockchainWallets } = await utils.rightService.verifyPayloadSignatures(params);
+      const { isAuthorized, blockchainWallets, details } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload:ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload:ErrorPayload[] = details;
         return callback(errorPayload);
       }
 

--- a/src/services/JSONRPCServer/users/users.ts
+++ b/src/services/JSONRPCServer/users/users.ts
@@ -85,12 +85,13 @@ export const userJSONRPCFactory = (networkParameters: NetworkParameters) => (
       const {
         isAuthorized,
         blockchainWallets,
-        proxyWalletAddress
+        proxyWalletAddress,
+        details
       } = await utils.rightService
         .verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload: ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload: ErrorPayload[] = details;
         return callback(errorPayload);
       }
 

--- a/src/services/JSONRPCServer/users/users.ts
+++ b/src/services/JSONRPCServer/users/users.ts
@@ -29,11 +29,12 @@ export const userJSONRPCFactory = (networkParameters: NetworkParameters) => (
 
       const {
         isAuthorized,
-        blockchainWallets
+        blockchainWallets,
+        details
       } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload: ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload: ErrorPayload[] = details;
         return callback(errorPayload);
       }
 
@@ -141,11 +142,12 @@ export const userJSONRPCFactory = (networkParameters: NetworkParameters) => (
 
       const {
         isAuthorized,
-        blockchainWallets
+        blockchainWallets,
+        details
       } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload: ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload: ErrorPayload[] = details;
         return callback(errorPayload);
       }
       const firstBlockchainWallet = blockchainWallets[0];
@@ -197,11 +199,12 @@ export const userJSONRPCFactory = (networkParameters: NetworkParameters) => (
 
       const {
         isAuthorized,
-        blockchainWallets
+        blockchainWallets,
+        details
       } = await utils.rightService.verifyPayloadSignatures(params);
 
       if (isAuthorized === false) {
-        const errorPayload: ErrorPayload = JSONRPCErrors.wrongSignatureForPayload;
+        const errorPayload: ErrorPayload[] = details;
         return callback(errorPayload);
       }
 

--- a/src/services/utils/services/rightService/rightService.test.ts
+++ b/src/services/utils/services/rightService/rightService.test.ts
@@ -75,7 +75,8 @@ describe('rightService', () => {
           {
             blockchainWallets: [],
             isAuthorized: false,
-            proxyWalletAddress: '0x931e35f78f7948dff3ea7d3bf45cb294f53c93cd'
+            proxyWalletAddress: '0x931e35f78f7948dff3ea7d3bf45cb294f53c93cd',
+            details: [null]
           });
       });
     });

--- a/src/services/utils/services/rightService/rightService.ts
+++ b/src/services/utils/services/rightService/rightService.ts
@@ -26,8 +26,7 @@ export class RightService {
       .map(authorization => {
         const { payload } = JWTDecoder(authorization).decode();
         const { iss, sub } = payload;
-        console.info('payload');
-        console.info(payload);
+
         const { isValid, details } = JWTDecoder(authorization).verify(iss);
 
         const isProxyWalletAuthorized = sub.toLowerCase() === publicKeyToVerify.toLowerCase();

--- a/src/services/utils/services/rightService/rightService.ts
+++ b/src/services/utils/services/rightService/rightService.ts
@@ -26,6 +26,8 @@ export class RightService {
       .map(authorization => {
         const { payload } = JWTDecoder(authorization).decode();
         const { iss, sub } = payload;
+        console.info('payload');
+        console.info(payload);
         const { isValid, details } = JWTDecoder(authorization).verify(iss);
 
         const isProxyWalletAuthorized = sub.toLowerCase() === publicKeyToVerify.toLowerCase();
@@ -51,8 +53,11 @@ export class RightService {
      * @returns {boolean}
      */
     public static isProxyWalletAuthorized=(authorizationsJWT:string[], publicKeyToVerify): { isAuthorized: boolean, details: ErrorPayload[] } => {
-      const { isAuthorized, details } = RightService.proxyWalletAuthorisationStatus(authorizationsJWT, publicKeyToVerify);
-      return { isAuthorized, details };
+      const authStatus = RightService.proxyWalletAuthorisationStatus(authorizationsJWT, publicKeyToVerify);
+      return {
+        isAuthorized: authStatus.isAuthorized,
+        details: authStatus.details
+      };
     }
 
     public static extractBlockchainWalletAddressWhoAuthorizedProxyWallet=

--- a/src/services/wallet/services/proxyWalletService/proxyWalletService.test.ts
+++ b/src/services/wallet/services/proxyWalletService/proxyWalletService.test.ts
@@ -36,8 +36,8 @@ describe('proxy wallet', () => {
     } = signerDecoder('0xc88c2ebe8243c838b54fcafebef2ae909556c8f96becfbbe4a2d49a9417c4161');
     const genericJWT = new JWTGeneric(signer, decoder);
 
-    const verify = genericJWT.setToken(proxyWallet.wallets.authorizations[0]).verify(address);
-    expect(verify).toBeTruthy();
+    const { isValid, details } = genericJWT.setToken(proxyWallet.wallets.authorizations[0]).verify(address);
+    expect(isValid).toBeTruthy();
 
     await proxyWallet.wallets.addWalletFromPrivateKey(pkBlockchainWallet1);
     expect(proxyWallet.wallets.authorizedAddresses).toHaveLength(1);

--- a/src/services/wallet/services/proxyWalletService/proxyWalletService.ts
+++ b/src/services/wallet/services/proxyWalletService/proxyWalletService.ts
@@ -80,7 +80,7 @@ export class ProxyWalletService {
       if (valueFromStorage) {
         try {
           const parseValue: any[] = JSON.parse(valueFromStorage);
-          const isAuthorized = RightService.isProxyWalletAuthorized(parseValue, this.address);
+          const { isAuthorized } = RightService.isProxyWalletAuthorized(parseValue, this.address);
           if (isAuthorized) {
             return parseValue;
           }

--- a/src/services/wallet/services/proxyWalletService/proxyWalletService.ts
+++ b/src/services/wallet/services/proxyWalletService/proxyWalletService.ts
@@ -172,7 +172,7 @@ export class ProxyWalletService {
 
   async addBlockchainWalletAuthorization (jwt): Promise<ProxyWalletService> {
     const issuer = this.jwtHelper.setToken(jwt).decode().payload.iss;
-    required(this.jwtHelper.setToken(jwt).verify(issuer), 'iss of jwt should be the issuer');
+    required(this.jwtHelper.setToken(jwt).verify(issuer).isValid, 'iss of jwt should be the issuer');
     if (!this._authorizedAddresses.includes(issuer)) {
       this._authorizedAddresses.push(issuer);
       this._authorizations.push(jwt);

--- a/src/services/wallet/services/roomService/roomService.test.ts
+++ b/src/services/wallet/services/roomService/roomService.test.ts
@@ -8,7 +8,6 @@ import {
 import axios from 'axios';
 import { skip, take } from 'rxjs/operators';
 import { getStore } from '../../../../stateManagement/src/store';
-import Web3 from 'web3';
 
 jest.setTimeout(60000);
 

--- a/src/services/wallet/services/roomService/roomService.test.ts
+++ b/src/services/wallet/services/roomService/roomService.test.ts
@@ -8,6 +8,7 @@ import {
 import axios from 'axios';
 import { skip, take } from 'rxjs/operators';
 import { getStore } from '../../../../stateManagement/src/store';
+import Web3 from 'web3';
 
 jest.setTimeout(60000);
 
@@ -33,6 +34,7 @@ describe('room', () => {
         .addWalletFromPrivateKey(d);
       return newSpkz;
     }));
+
     proxyWallet = proxiesWallet[0];
   });
 


### PR DESCRIPTION
This feature allows for more specific error messages in the JWT verification, we can now see whether it is a signature/auth problem or if it is a JWT problem (nbf, iat, expired)

JWT errors are in a specific file called `JWTGenericErrors`

Tests pass but I think it would be good to test it in real conditions (i.e. in browser, have an expired || time < iat || time < nbf || public key/decoded key mismatch  JWT and access SPKZ with it to see if everything works fine)

Also: I question the utility of `JSONRPCErrors.wrongSignatureForPayload` since, even if it can be returned by a RPC call, it's mostly the responsibility of the JWT service? (in this PR in fact, it is not used, `JWTGenericErrors.publicKeyAndDecodedKeyMismatch` is used instead)